### PR TITLE
fix: update the status code for throttling exception

### DIFF
--- a/src/main/java/edu/ksu/canvas/net/SimpleRestClient.java
+++ b/src/main/java/edu/ksu/canvas/net/SimpleRestClient.java
@@ -343,7 +343,7 @@ public class SimpleRestClient implements RestClient {
             LOG.error("User is not authorized to perform this action");
             throw new UnauthorizedException();
         }
-        if(statusCode == 403) {
+        if(statusCode == 429) {
             LOG.error("Canvas has throttled this request. Requested URL: " + uri);
             throw new ThrottlingException(extractErrorMessageFromResponse(httpResponse), String.valueOf(uri));
         }

--- a/src/test/java/edu/ksu/canvas/net/SimpleRestClientUTest.java
+++ b/src/test/java/edu/ksu/canvas/net/SimpleRestClientUTest.java
@@ -50,10 +50,10 @@ public class SimpleRestClientUTest extends LocalServerTestBase {
     }
 
     @Test
-    void http403ThrottlingThrowsException() throws Exception {
+    void http429ThrottlingThrowsException() throws Exception {
         String url = "/throttledUrl";
         //Using blank JSON because I haven't been able to observe this error so I don't know what payload it returns
-        registerUrlResponse(url, "/SampleJson/BlankResponse.json", 403, Collections.emptyMap());
+        registerUrlResponse(url, "/SampleJson/BlankResponse.json", 429, Collections.emptyMap());
 
         assertThrows(ThrottlingException.class, () -> {
             restClient.sendApiGet(emptyAdminToken, baseUrl + url, 100, 100);


### PR DESCRIPTION
I just noticed that our canvas-api library does not handle throttling correctly. It currently checks for a 403 status code, which is outdated according to the Canvas documentation. We should update the library to check for 429 (Too Many Requests) and throw a ThrottlingException instead.
 
https://github.com/UCBoulder/canvas-api/blob/e44adec40f205bc1e09b9360ad3b9cd192f78257/src/main/java/edu/ksu/canvas/net/SimpleRestClient.java#L346

<img width="2084" height="914" alt="image" src="https://github.com/user-attachments/assets/3f2f6951-1fd3-4e00-827d-36d473b9aedd" />